### PR TITLE
Mac support and option to specify delimiter

### DIFF
--- a/utils/logger.py
+++ b/utils/logger.py
@@ -1,25 +1,29 @@
 import os
 import platform
+import warnings
 
 from pathlib import Path
 from datetime import datetime
+from traceback import format_exc
 
 class Logger:
-    def __init__(self, filename=None):
+    def __init__(self, filename=None, delimiter=","):
         if filename is not None:
             self.filename = filename 
         else: 
             self.filename = "%s-%s.log" % (Path(__file__).stem, datetime.now().strftime("%d-%m-%Y_%H-%M-%S"))
+        self.delimiter = delimiter
  
     def log_data(self, data:[[]], folder="datalogs"):
-        sl = "\\."[0] if platform.system() == "Windows" else "/"
+        sl = "/" if platform.system() == "Linux" else "\\."[0]
         if not os.path.exists(os.path.join(Path(__file__).parent.parent.resolve(),"logs"+sl+"%s" % folder)):
             os.makedirs(os.path.join(Path(__file__).parent.parent.resolve(), "logs"+sl+"%s" % folder))
         try:
             with open(os.path.join(Path(__file__).parent.parent.resolve(), "logs"+sl+"%s" % folder + sl + "%s" % self.filename), "a") as log:
                 for row in data:
-                    log.write(((("%s, "*len(row))[:-2]) % tuple(row))+"\n")
+                    log.write((((("%s"+"%s " % self.delimiter)*len(row))[:-2]) % (tuple(row)))+"\n")
             return(1)
-        except:
-            warn("\n[WARNING] Couldn't create or write in logfile %s. Will skip logging in the future" % self.filename)
+        except Exception as e:
+            print(format_exc())
+            warnings.warn("\n[WARNING] Couldn't create or write in logfile %s. Will skip logging in the future" % self.filename)
             return (-1)


### PR DESCRIPTION
- You can now specify what symbol should be used as the delimiter when logging data
- Prints the traceback if an error occured
- Added Mac support